### PR TITLE
fix: bad description

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -23,6 +23,8 @@ markup:
     startLevel: 1
 
 params:
+  description: 一份适合电脑小白入门的电脑使用课程和面向今日与未来的信息时代指南
+
   BookTheme: "light"
   BookMenuBundle: /menu
   BookSearch: false

--- a/themes/hugo-book/layouts/partials/docs/html-head.html
+++ b/themes/hugo-book/layouts/partials/docs/html-head.html
@@ -1,9 +1,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="description" content="{{ default .Summary .Description }}">
+<meta name="description" content="{{ default .Site.Params.Description }}">
 <meta name="theme-color" content="#FFFFFF">
 
-{{- template "_internal/opengraph.html" . -}}
+{{ partial "docs/opengraph" . }}
 
 <title>{{ partial "docs/title" . }} | 你缺失的那门计算机课 | 计算机技术学习札记</title>
 

--- a/themes/hugo-book/layouts/partials/docs/opengraph.html
+++ b/themes/hugo-book/layouts/partials/docs/opengraph.html
@@ -1,0 +1,74 @@
+<meta property="og:url" content="{{ .Permalink }}">
+
+{{- with or site.Title site.Params.title | plainify }}
+  <meta property="og:site_name" content="{{ . }}">
+{{- end }}
+
+{{- with or .Title site.Title site.Params.title | plainify }}
+  <meta property="og:title" content="{{ . }}">
+{{- end }}
+
+{{- with or .Site.Params.Description | plainify | htmlUnescape }}
+  <meta property="og:description" content="{{ . }}">
+{{- end }}
+
+{{- with or .Params.locale site.Language.LanguageCode }}
+  <meta property="og:locale" content="{{ replace . `-` `_` }}">
+{{- end }}
+
+{{- if .IsPage }}
+  <meta property="og:type" content="article">
+  {{- with .Section }}
+    <meta property="article:section" content="{{ . }}">
+  {{- end }}
+  {{- $ISO8601 := "2006-01-02T15:04:05-07:00" }}
+  {{- with .PublishDate }}
+    <meta property="article:published_time" {{ .Format $ISO8601 | printf "content=%q" | safeHTMLAttr }}>
+  {{- end }}
+  {{- with .Lastmod }}
+    <meta property="article:modified_time" {{ .Format $ISO8601 | printf "content=%q" | safeHTMLAttr }}>
+  {{- end }}
+  {{- range .GetTerms "tags" | first 6 }}
+    <meta property="article:tag" content="{{ .Page.Title | plainify }}">
+  {{- end }}
+{{- else }}
+  <meta property="og:type" content="website">
+{{- end }}
+
+{{- with partial "_funcs/get-page-images" . }}
+  {{- range . | first 6 }}
+    <meta property="og:image" content="{{ .Permalink }}">
+  {{- end }}
+{{- end }}
+
+{{- with .Params.audio }}
+  {{- range . | first 6  }}
+    <meta property="og:audio" content="{{ . | absURL }}">
+  {{- end }}
+{{- end }}
+
+{{- with .Params.videos }}
+  {{- range . | first 6 }}
+    <meta property="og:video" content="{{ . | absURL }}">
+  {{- end }}
+{{- end }}
+
+{{- range .GetTerms "series" }}
+  {{- range .Pages | first 7 }}
+    {{- if ne $ . }}
+      <meta property="og:see_also" content="{{ .Permalink }}">
+    {{- end }}
+  {{- end }}
+{{- end }}
+
+{{- with site.Params.social }}
+  {{- if reflect.IsMap . }}
+    {{- with .facebook_app_id }}
+      <meta property="fb:app_id" content="{{ . }}">
+    {{- else }}
+      {{- with .facebook_admin }}
+        <meta property="fb:admins" content="{{ . }}">
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}


### PR DESCRIPTION
Related to issue #5 

## Changes

- add param "description" in `hugo.yaml`
- using specific `.Site.Params.Description` instead of the original one
- using new `opengraph.html` which copied from [hugo repo](https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/opengraph.html) with the description changed instead of original internal template

By the way, I have concat the first sentences in p1 and p2 of the home page to make this new description.
If you want to change it, just modify the content in `hugo.yaml`.

## Result

<img width="511" alt="截屏2025-02-14 22 43 05" src="https://github.com/user-attachments/assets/35bd3bd7-d9ab-4f9f-befb-459ac9169cee" />

## What's more

My device had already installed hugo with version `hugo v0.136.5+extended darwin/arm64 BuildDate=2024-10-24T12:26:27Z VendorInfo=brew`, so when I run `hugo server` it throwed the error:

<img width="1433" alt="截屏2025-02-14 22 45 53" src="https://github.com/user-attachments/assets/fa8e40ae-1667-4cbb-817e-6bd8322d4a41" />

So I need to comment out these codes in `themes/hugo-book/layouts/partials/docs/footer.html`:

https://github.com/criwits/missing-web/blob/40682fee6a6a3660bc415879b9a6a4c94b204409/themes/hugo-book/layouts/partials/docs/footer.html#L2-L4

Wish it could be pointed out in README for new developers who also have a newer hugo version installed.

