### PR TITLE
修复 GitHub Star 数历史图表无法加载

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@
 
 自诞生以来，本仓库的 Star 数变化如下图所示：
 
-![GitHub Star 数历史](https://api.star-history.com/svg?repos=criwits/missing-web&type=Date)
+![GitHub Star 数历史](https://star-history.dera.page/svg?repos=criwits/missing-web&type=Date)
 
-以上图表由 [star-history.com](https://star-history.com/) 提供。
+以上图表由 [star-history.dera.page](https://star-history.dera.page/) 提供。

--- a/content/_index.md
+++ b/content/_index.md
@@ -145,6 +145,6 @@ chapter: -2
 
 自 2021 年 12 月 26 日以来，《你缺失的那门计算机课》网页版 GitHub 仓库的 Star 数变化如下图所示：
 
-<img src="https://api.star-history.com/svg?repos=criwits/missing-web&amp;type=Date" alt="GitHub Star 统计图暂无法加载" loading="lazy">
+<img src="https://star-history.dera.page/svg?repos=criwits/missing-web&amp;type=Date" alt="GitHub Star 统计图暂无法加载" loading="lazy">
 
-以上图表由 [star-history.com](https://star-history.com/) 提供。
+以上图表由 [star-history.dera.page](https://star-history.dera.page/) 提供。


### PR DESCRIPTION
目前首页及 README 中的 GitHub Star 数历史图表因数据源限制已无法正常显示，影响读者对该项目发展情况的了解。本改动将图表切换到新的可用数据源，使其恢复显示，其余内容不变